### PR TITLE
Bugfix in FreeFieldDirectivityTF_1.1.csv

### DIFF
--- a/SOFAtoolbox/conventions/FreeFieldDirectivityTF_1.1.csv
+++ b/SOFAtoolbox/conventions/FreeFieldDirectivityTF_1.1.csv
@@ -24,6 +24,7 @@ GLOBAL:Musician				attribute	Narrative description of the musician such as posit
 GLOBAL:Description				attribute	Narrative description of a measurement. For musical instruments/singers, the note (C1, D1, etc) or the dynamic (pp., ff., etc), or the string played, the playing style (pizzicato, legato, etc.), or the type of excitation (e.g., hit location of a cymbal). For loudspeakers, the system and driver units.
 GLOBAL:SourceType		m		attribute	Narrative description of the acoustic source, e.g., 'Violin', 'Female singer', or '2-way loudspeaker'
 GLOBAL:SourceManufacturer		m		attribute	Narrative description of the manufacturer of the source, e.g., 'Stradivari, Lady Blunt, 1721' or 'LoudspeakerCompany'
+GLOBAL:EmitterDescription				attribute	A more detailed structure of the source. In a simple setting, a single Emitter is considered that is collocated with the source. In a more complicated setting, this may be the strings of a violin or the units of a loudspeaker.
 ListenerPosition	[0 0 0] 	m	IC, MC	double	Position of the microphone array during the measurements.
 ListenerPosition:Type	cartesian	m		attribute
 ListenerPosition:Units	metre	m		attribute
@@ -47,7 +48,6 @@ SourceUp:Reference		m		attribute	Narrative description of the spatial reference 
 EmitterPosition	[0 0 0]	m	eC, eCM	double	Position. In a simple settings, a single emitter is considered that is collocated with the source.
 EmitterPosition:Type	cartesian	m		attribute
 EmitterPosition:Units	metre	m		attribute
-GLOBAL:EmitterDescription	{''}		IS, MS	attribute	A more detailed structure of the source. In a simple setting, a single Emitter is considered that is collocated with the source. In a more complicated setting, this may be the strings of a violin or the units of a loudspeaker.
 EmitterDescriptions	{''}		MS, ES, MES	string	A more detailed description of the Emitters. For example, this may be the strings of a violin or the units of a loudspeaker.
 MIDINote	0		I, M	double	Defines the note played by the source during the measurement. The note is specified a MIDI note by the [https://www.midi.org/specifications-old/item/the-midi-1-0-specification MIDI specifications, version 1.0]. Not mandatory, but recommended for tonal instruments.
 Description	{''}		MS	string	This variable is used when the description varies with M.


### PR DESCRIPTION
There were two small bugs in the field *GLOBAL:EmitterDescription*. The default value and dimensions must be empty because this is an attribute and not a variable. I also moved the field up to the other Global attributes