### PR TITLE
re-introduce lost conventions

### DIFF
--- a/SOFAtoolbox/conventions/SimpleFreeFieldHRIR_0.4.csv
+++ b/SOFAtoolbox/conventions/SimpleFreeFieldHRIR_0.4.csv
@@ -1,0 +1,43 @@
+Name	Default	Flags	Dimensions	Type	Comment
+GLOBAL:Conventions	SOFA	rm	  	attribute	
+GLOBAL:Version	1.0	rm	 	attribute	
+GLOBAL:SOFAConventions	SimpleFreeFieldHRIR	rm	  	attribute	This convention set is for HRIRs recorded under free-field conditions or other IRs created under conditions where room information is irrelevant
+GLOBAL:SOFAConventionsVersion	0.4	rm	  	attribute	
+GLOBAL:APIName		rm	  	attribute	
+GLOBAL:APIVersion		rm	  	attribute	
+GLOBAL:ApplicationName			  	attribute	
+GLOBAL:ApplicationVersion			  	attribute	
+GLOBAL:AuthorContact		m	  	attribute	
+GLOBAL:Comment			 	attribute	
+GLOBAL:DataType	FIR	rm	  	attribute	
+GLOBAL:History			 	attribute	
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
+GLOBAL:Organization		m	  	attribute	
+GLOBAL:References				attribute	
+GLOBAL:RoomType	free field	m	  	attribute	
+GLOBAL:Origin				attribute	
+GLOBAL:DateCreated		m	 	attribute	
+GLOBAL:DateModified		m	 	attribute	
+GLOBAL:Title		m		attribute	
+ListenerPosition	[0 0 0] 	m	IC, MC	double	
+ListenerPosition:Type	cartesian	m	  	attribute	
+ListenerPosition:Units	meter	m	  	attribute	
+ReceiverPosition	[0 0.09 0; 0 -0.09 0]	m	rCI, rCM	double	
+ReceiverPosition:Type	cartesian	m	  	attribute	
+ReceiverPosition:Units	meter	m	  	attribute	
+SourcePosition	[0 0 1]	m	IC, MC	double	Source position is assumed to vary for different directions/positions around the listener
+SourcePosition:Type	spherical	m	  	attribute	
+SourcePosition:Units	degree, degree, meter	m	  	attribute	
+EmitterPosition	[0 0 0]	m	eCI, eCM	double	
+EmitterPosition:Type	cartesian	m	  	attribute	
+EmitterPosition:Units	meter	m	  	attribute	
+GLOBAL:DatabaseName		m	  	attribute	name of the database to which these data belong
+GLOBAL:ListenerShortName		m	  	attribute	ID of the subject from the database
+ListenerUp	[0 0 1]	m	IC, MC	double	
+ListenerView	[1 0 0]	m	IC, MC	double	
+ListenerView:Type	cartesian	m		attribute	
+ListenerView:Units	meter	m		attribute	
+Data.IR	[1 1]	m	mRn	double	
+Data.SamplingRate	48000	m	I	double	
+Data.SamplingRate:Units	hertz	m		attribute	
+Data.Delay	[0 0]	m	IR, MR	double	

--- a/SOFAtoolbox/conventions/SimpleFreeFieldTF_0.4.csv
+++ b/SOFAtoolbox/conventions/SimpleFreeFieldTF_0.4.csv
@@ -1,0 +1,44 @@
+Name	Default	Flags	Dimensions	Type	Comment
+GLOBAL:Conventions	SOFA	rm	  	attribute	
+GLOBAL:Version	1.0	rm	 	attribute	
+GLOBAL:SOFAConventions	SimpleFreeFieldTF	rm	  	attribute	This conventions is for TFs created under conditions where room information is irrelevant
+GLOBAL:SOFAConventionsVersion	0.4	rm	  	attribute	
+GLOBAL:APIName		rm	  	attribute	
+GLOBAL:APIVersion		rm	  	attribute	
+GLOBAL:ApplicationName			  	attribute	
+GLOBAL:ApplicationVersion			  	attribute	
+GLOBAL:AuthorContact		m	  	attribute	
+GLOBAL:Comment			 	attribute	
+GLOBAL:DataType	TF	rm	  	attribute	
+GLOBAL:History			 	attribute	
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
+GLOBAL:ListenerShortName		m		attribute	ID of the subject from the database
+GLOBAL:Organization		m	  	attribute	
+GLOBAL:References				attribute	
+GLOBAL:RoomType	free field	m	  	attribute	
+GLOBAL:Origin				attribute	
+GLOBAL:DateCreated		m	 	attribute	
+GLOBAL:DateModified		m	 	attribute	
+GLOBAL:Title		m		attribute	
+ListenerPosition	[0 0 0] 	m	IC, MC	double	
+ListenerPosition:Type	cartesian	m	  	attribute	
+ListenerPosition:Units	meter	m	  	attribute	
+ReceiverPosition	[0 0.09 0; 0 -0.09 0]	m	rCI, rCM	double	
+ReceiverPosition:Type	cartesian	m	  	attribute	
+ReceiverPosition:Units	meter	m	  	attribute	
+SourcePosition	[0 0 1]	m	IC, MC	double	Source position is assumed to vary for different directions/positions around the listener
+SourcePosition:Type	spherical	m	  	attribute	
+SourcePosition:Units	degree, degree, meter	m	  	attribute	
+EmitterPosition	[0 0 0]	m	eCI, eCM	double	
+EmitterPosition:Type	cartesian	m	  	attribute	
+EmitterPosition:Units	meter	m	  	attribute	
+GLOBAL:DatabaseName		m	  	attribute	name of the database to which these data belong
+ListenerUp	[0 0 1]	m	IC, MC	double	
+ListenerView	[1 0 0]	m	IC, MC	double	
+ListenerView:Type	cartesian	m		attribute	
+ListenerView:Units	meter	m		attribute	
+Data.Real	[1 1]	m	mRn	double	
+Data.Imag	[0 0]	m	MRN	double	
+N	0	m	N	double	
+N_LongName	frequency			attribute	
+N_Units	hertz			attribute	

--- a/SOFAtoolbox/conventions/SimpleFreeFieldTF_1.0.csv
+++ b/SOFAtoolbox/conventions/SimpleFreeFieldTF_1.0.csv
@@ -1,0 +1,44 @@
+Name	Default	Flags	Dimensions	Type	Comment
+GLOBAL:Conventions	SOFA	rm	  	attribute	
+GLOBAL:Version	1.0	rm	 	attribute	
+GLOBAL:SOFAConventions	SimpleFreeFieldTF	rm	  	attribute	This conventions is for TFs created under conditions where room information is irrelevant
+GLOBAL:SOFAConventionsVersion	1.0	rm	  	attribute	
+GLOBAL:APIName		rm	  	attribute	
+GLOBAL:APIVersion		rm	  	attribute	
+GLOBAL:ApplicationName			  	attribute	
+GLOBAL:ApplicationVersion			  	attribute	
+GLOBAL:AuthorContact		m	  	attribute	
+GLOBAL:Comment			 	attribute	
+GLOBAL:DataType	TF	rm	  	attribute	
+GLOBAL:History			 	attribute	
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
+GLOBAL:ListenerShortName		m		attribute	ID of the subject from the database
+GLOBAL:Organization		m	  	attribute	
+GLOBAL:References				attribute	
+GLOBAL:RoomType	free field	m	  	attribute	
+GLOBAL:Origin				attribute	
+GLOBAL:DateCreated		m	 	attribute	
+GLOBAL:DateModified		m	 	attribute	
+GLOBAL:Title		m		attribute	
+ListenerPosition	[0 0 0] 	m	IC, MC	double	
+ListenerPosition:Type	cartesian	m	  	attribute	
+ListenerPosition:Units	metre	m	  	attribute	
+ReceiverPosition	[0 0.09 0; 0 -0.09 0]	m	rCI, rCM	double	
+ReceiverPosition:Type	cartesian	m	  	attribute	
+ReceiverPosition:Units	metre	m	  	attribute	
+SourcePosition	[0 0 1]	m	IC, MC	double	Source position is assumed to vary for different directions/positions around the listener
+SourcePosition:Type	spherical	m	  	attribute	
+SourcePosition:Units	degree, degree, metre	m	  	attribute	
+EmitterPosition	[0 0 0]	m	eCI, eCM	double	
+EmitterPosition:Type	cartesian	m	  	attribute	
+EmitterPosition:Units	metre	m	  	attribute	
+GLOBAL:DatabaseName		m	  	attribute	name of the database to which these data belong
+ListenerUp	[0 0 1]	m	IC, MC	double	
+ListenerView	[1 0 0]	m	IC, MC	double	
+ListenerView:Type	cartesian	m		attribute	
+ListenerView:Units	metre	m		attribute	
+Data.Real	[0 0]	m	mRn	double	
+Data.Imag	[0 0]	m	MRN	double	
+N	0	m	N	double	
+N_LongName	frequency			attribute	
+N_Units	hertz			attribute	

--- a/SOFAtoolbox/conventions/SimpleHeadphoneIR_0.1.csv
+++ b/SOFAtoolbox/conventions/SimpleHeadphoneIR_0.1.csv
@@ -1,0 +1,51 @@
+Name	Default	Flags	Dimensions	Type	Comment
+GLOBAL:Conventions	SOFA	rm	  	attribute	
+GLOBAL:Version	1.0	rm	 	attribute	
+GLOBAL:SOFAConventions	SimpleHeadphoneIR	rm	  	attribute	Conventions for IRs with a 1-to-1 correspondence between emitter and receiver. The main application for this convention is to store headphone IRs recorded for each emitter and each ear.
+GLOBAL:SOFAConventionsVersion	0.1	rm	  	attribute	
+GLOBAL:APIName		rm	  	attribute	
+GLOBAL:APIVersion		rm	  	attribute	
+GLOBAL:ApplicationName			  	attribute	
+GLOBAL:ApplicationVersion			  	attribute	
+GLOBAL:AuthorContact		m	  	attribute	
+GLOBAL:Comment		m	 	attribute	
+GLOBAL:DataType	FIR	rm	  	attribute	We will store IRs here
+GLOBAL:History			 	attribute	
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
+GLOBAL:Organization		m	  	attribute	
+GLOBAL:References				attribute	
+GLOBAL:RoomType	free field	m	  	attribute	Room type is not relevant here
+GLOBAL:Origin				attribute	
+GLOBAL:DateCreated		m	 	attribute	
+GLOBAL:DateModified		m	 	attribute	
+GLOBAL:Title		m		attribute	
+ListenerPosition	[0 0 0] 	m	IC, MC	double	
+ListenerPosition:Type	cartesian	m	  	attribute	
+ListenerPosition:Units	meter	m	  	attribute	
+ReceiverPosition	[0 0.09 0; 0 -0.09 0]	m	rCI, rCM	double	
+ReceiverPosition:Type	cartesian	m	  	attribute	
+ReceiverPosition:Units	meter	m	  	attribute	
+SourcePosition	[0 0 0]	m	IC, MC	double	Default: Headphones are located at the position of the listener
+SourcePosition:Type	spherical	m	  	attribute	
+SourcePosition:Units	degree, degree, meter	m	  	attribute	
+EmitterPosition	[0 0.09 0; 0 -0.09 0]	m	eCI, eCM	double	Default: Reflects the correspondence of each emitter to each receiver
+EmitterPosition:Type	cartesian	m	  	attribute	
+EmitterPosition:Units	meter	m	  	attribute	
+Data.IR	[1 1]	m	mRn	double	
+Data.SamplingRate	48000	m	I	double	
+Data.SamplingRate:Units	hertz	m		attribute	
+Data.Delay	[0 0]	m	IR, MR	double	
+GLOBAL:DatabaseName		m	  	attribute	Correspondence to a database
+GLOBAL:ListenerShortName		m	  	attribute	Correspondence to a subject from the database
+GLOBAL:ListenerDescription		m		attribute	Narrative description of the listener (or mannequin)
+GLOBAL:SourceDescription		m		attribute	Narrative description of the headphones
+GLOBAL:SourceManufacturer		m		attribute	Name of the headphones manufacturer
+SourceManufacturer	{''}		MS	string	Optional M-dependent version of the attribute SourceManufucturer
+GLOBAL:SourceModel		m		attribute	Name of the headphone model. Must uniquely describe the headphones of the manufacturer
+SourceModel	{''}		MS	string	Optional M-dependent version of the attribute SourceModel
+GLOBAL:SourceURI		m		attribute	URI of the headphone specifications
+GLOBAL:ReceiverDescription		m		attribute	Narrative description of the microphones
+ReceiverDescription	{''}		MS	string	Optional M-dependent version of the attribute ReceiverDescription
+GLOBAL:EmitterDescription		m		attribute	Narrative description of the headphone drivers
+EmitterDescription	{''}		MS	string	Optional M-dependent version of the attribute EmitterDescription
+MeasurementDate	0		M	double	Optional M-dependent date and time of the measurement

--- a/SOFAtoolbox/conventions/SimpleHeadphoneIR_0.2.csv
+++ b/SOFAtoolbox/conventions/SimpleHeadphoneIR_0.2.csv
@@ -1,0 +1,51 @@
+Name	Default	Flags	Dimensions	Type	Comment
+GLOBAL:Conventions	SOFA	rm	  	attribute	
+GLOBAL:Version	1.0	rm	 	attribute	
+GLOBAL:SOFAConventions	SimpleHeadphoneIR	rm	  	attribute	Conventions for IRs with a 1-to-1 correspondence between emitter and receiver. The main application for this convention is to store headphone IRs recorded for each emitter and each ear.
+GLOBAL:SOFAConventionsVersion	0.2	rm	  	attribute	
+GLOBAL:APIName		rm	  	attribute	
+GLOBAL:APIVersion		rm	  	attribute	
+GLOBAL:ApplicationName			  	attribute	
+GLOBAL:ApplicationVersion			  	attribute	
+GLOBAL:AuthorContact		m	  	attribute	
+GLOBAL:Comment		m	 	attribute	
+GLOBAL:DataType	FIR	rm	  	attribute	We will store IRs here
+GLOBAL:History			 	attribute	
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
+GLOBAL:Organization		m	  	attribute	
+GLOBAL:References				attribute	
+GLOBAL:RoomType	free field	m	  	attribute	Room type is not relevant here
+GLOBAL:Origin				attribute	
+GLOBAL:DateCreated		m	 	attribute	
+GLOBAL:DateModified		m	 	attribute	
+GLOBAL:Title		m		attribute	
+ListenerPosition	[0 0 0] 	m	IC, MC	double	
+ListenerPosition:Type	cartesian	m	  	attribute	
+ListenerPosition:Units	metre	m	  	attribute	
+ReceiverPosition	[0 0.09 0; 0 -0.09 0]	m	rCI, rCM	double	
+ReceiverPosition:Type	cartesian	m	  	attribute	
+ReceiverPosition:Units	metre	m	  	attribute	
+SourcePosition	[0 0 0]	m	IC, MC	double	Default: Headphones are located at the position of the listener
+SourcePosition:Type	spherical	m	  	attribute	
+SourcePosition:Units	degree, degree, metre	m	  	attribute	
+EmitterPosition	[0 0.09 0; 0 -0.09 0]	m	eCI, eCM	double	Default: Reflects the correspondence of each emitter to each receiver
+EmitterPosition:Type	cartesian	m	  	attribute	
+EmitterPosition:Units	metre	m	  	attribute	
+Data.IR	[0 0]	m	mRn	double	
+Data.SamplingRate	48000	m	I	double	
+Data.SamplingRate:Units	hertz	m		attribute	
+Data.Delay	[0 0]	m	IR, MR	double	
+GLOBAL:DatabaseName		m	  	attribute	Correspondence to a database
+GLOBAL:ListenerShortName		m	  	attribute	Correspondence to a subject from the database
+GLOBAL:ListenerDescription		m		attribute	Narrative description of the listener (or mannequin)
+GLOBAL:SourceDescription		m		attribute	Narrative description of the headphones
+GLOBAL:SourceManufacturer		m		attribute	Name of the headphones manufacturer
+SourceManufacturer	{''}		MS	string	Optional M-dependent version of the attribute SourceManufucturer
+GLOBAL:SourceModel		m		attribute	Name of the headphone model. Must uniquely describe the headphones of the manufacturer
+SourceModel	{''}		MS	string	Optional M-dependent version of the attribute SourceModel
+GLOBAL:SourceURI		m		attribute	URI of the headphone specifications
+GLOBAL:ReceiverDescription		m		attribute	Narrative description of the microphones
+ReceiverDescription	{''}		MS	string	Optional M-dependent version of the attribute ReceiverDescription
+GLOBAL:EmitterDescription		m		attribute	Narrative description of the headphone drivers
+EmitterDescription	{''}		MS	string	Optional M-dependent version of the attribute EmitterDescription
+MeasurementDate	0		M	double	Optional M-dependent date and time of the measurement

--- a/SOFAtoolbox/conventions/SingleRoomDRIR_0.2.csv
+++ b/SOFAtoolbox/conventions/SingleRoomDRIR_0.2.csv
@@ -1,0 +1,47 @@
+Name	Default	Flags	Dimensions	Type	Comment
+GLOBAL:Conventions	SOFA	rm	  	attribute	
+GLOBAL:Version	1.0	rm	 	attribute	
+GLOBAL:SOFAConventions	SingleRoomDRIR	rm	  	attribute	This convention stores arbitrary number of receivers while providing an information about the room. The main application is to store DRIRs for a single room.
+GLOBAL:SOFAConventionsVersion	0.2	rm	  	attribute	
+GLOBAL:APIName		rm	  	attribute	
+GLOBAL:APIVersion		rm	  	attribute	
+GLOBAL:ApplicationName			  	attribute	
+GLOBAL:ApplicationVersion			  	attribute	
+GLOBAL:AuthorContact		m	  	attribute	
+GLOBAL:Comment		m	 	attribute	
+GLOBAL:DataType	FIR	rm	  	attribute	
+GLOBAL:History			 	attribute	
+GLOBAL:License	No license provided, ask the author for permission	m	  	attribute	
+GLOBAL:Organization		m	  	attribute	
+GLOBAL:References				attribute	
+GLOBAL:RoomType	reverberant	m	  	attribute	
+GLOBAL:Origin				attribute	
+GLOBAL:DateCreated		m	 	attribute	
+GLOBAL:DateModified		m	 	attribute	
+GLOBAL:Title		m		attribute	
+ListenerPosition	[0 0 0] 	m	IC, MC	double	
+ListenerPosition:Type	cartesian	m	  	attribute	
+ListenerPosition:Units	meter	m	  	attribute	
+ReceiverPosition	[0 0 0]	m	rCI, rCM	double	
+ReceiverPosition:Type	cartesian	m	  	attribute	
+ReceiverPosition:Units	meter	m	  	attribute	
+SourcePosition	[0 0 0]	m	IC, MC	double	
+SourcePosition:Type	cartesian	m	  	attribute	
+SourcePosition:Units	meter	m	  	attribute	
+EmitterPosition	[0 0 0]	m	eCI, eCM	double	
+EmitterPosition:Type	cartesian	m	  	attribute	
+EmitterPosition:Units	meter	m	  	attribute	
+GLOBAL:DatabaseName		m	  	attribute	
+GLOBAL:RoomDescription		m	  	attribute	
+ListenerUp	[0 0 1]	m	IC, MC	double	
+ListenerView	[1 0 0]	m	IC, MC	double	
+ListenerView:Type	cartesian	m		attribute
+ListenerView:Units	metre	m		attribute	
+SourceUp	[0 0 1]	m	IC, MC	double	
+SourceView	[-1 0 0]	m	IC, MC	double	
+SourceView:Type	cartesian	m		attribute	
+SourceView:Units	metre	m		attribute   
+Data.IR	[1]	m	mRn	double	
+Data.SamplingRate	48000	m	I	double	
+Data.SamplingRate:Units	hertz	m		attribute	
+Data.Delay	[0]	m	IR, MR	double	


### PR DESCRIPTION
Some versions of conventions have been lost. That was a heritage from the time when the versions were not contained in the convention names. I did not bring back all systematically but only those where we found data using the respective conventions. All conventions were verified with sofar.

SimpleFreeFieldHRIR_0.4
-----------------------
Taken from 11 May 2015
97675dbfff6aadf373f3c17f688ca29685dc0107
Updated from 0.4 to 1.0 on May 11th (changed defaults from meter to metre)
cb2f474d4dc1c9325a6b0b5ee5b41f08e0db6338

SimpleHeadphoneIR_0.2
---------------------
Taken from Aug. 11 2020
7e8df153af95bb2b1c92930261ff621b0fefc14c
Updated to 1.0 in Oct. 12 2020
6d4c2a8fd6f6d2bf463ec1e9c708e0d8f9ebfbe9

SimpleHeadphoneIR_0.1
---------------------
Taken from 11 May 2015
97675dbfff6aadf373f3c17f688ca29685dc0107
Update from 0.1 to 0.2 in May 11 2015 (changed defaults from meter to metre)
cb2f474d4dc1c9325a6b0b5ee5b41f08e0db6338

SingleRoomDRIR_0.2
------------------
Taken from 11 May 2015
97675dbfff6aadf373f3c17f688ca29685dc0107
Update from 0.2 to 0.3 in May 11 2015 (changed defaults from meter to metre)
cb2f474d4dc1c9325a6b0b5ee5b41f08e0db6338

Added missing default fields ListenerView_Units and SourceView_Units
Fixed wrong defaults for Data:IR and Data:Delay

SimpleFreeFieldTF_1.0
---------------------
Taken from Jul 21 2020
564a609f529ff26cd6e359cc47215a7df7445afb
Renamed to SimpleFreeFieldHRTF and bumped version from 1.0 to 2.0 on Jul 24
56b2e15245d9a94973e32bfd6e74fdd5c204869f

SimpleFreeFieldTF_0.4
---------------------
Taken from 11 May 2015
97675dbfff6aadf373f3c17f688ca29685dc0107
Update from 0.4 to 1.0 in May 11 2015 (changed defaults from meter to metre)
cb2f474d4dc1c9325a6b0b5ee5b41f08e0db6338